### PR TITLE
Doesn't run ActiveSupport::JSON.decode(value) unless value starts with '{' and ends with '}'

### DIFF
--- a/lib/nested_hstore/serializer.rb
+++ b/lib/nested_hstore/serializer.rb
@@ -103,11 +103,10 @@ module NestedHstore
     # This isn't ideal: how do we know whether each value in an hstore is JSON or a
     # string/integer/etc?
     def decode_json_if_json(value)
-      begin
-        ActiveSupport::JSON.decode(value)
-      rescue
-        value
-      end
+      return value unless value.start_with?('{') && value.end_with?('}')
+      ActiveSupport::JSON.decode(value)
+    rescue
+      value
     end
 
     def encode_json(value)

--- a/spec/nested_hstore/serializer_spec.rb
+++ b/spec/nested_hstore/serializer_spec.rb
@@ -44,7 +44,7 @@ describe NestedHstore::Serializer do
 
   context 'with an array' do
     before :each do
-      @deserialized = (0..10).to_a
+      @deserialized = ('0'..'10').to_a
       @serialized = {
        "0"=>"0",
        "1"=>"1",


### PR DESCRIPTION
This fixes my issue described here tombenner/nested-hstore/1

I did break one of the specs.  I'm not sure if this is desirable behavior or not...

  1) NestedHstore::Serializer with an array #deserialize deserializes
     Failure/Error: deserialized.should == @deserialized
       expected: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
            got: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"](using ==)
     # ./spec/nested_hstore/serializer_spec.rb:13:in `it_deserializes'
     # ./spec/nested_hstore/serializer_spec.rb:69:in`block (4 levels) in <top (required)>'

So I patched the spec as well to expect strings instead of integers.
