### PR TITLE
Tiny fix for rails4

### DIFF
--- a/lib/active_record/coders/nested_hstore.rb
+++ b/lib/active_record/coders/nested_hstore.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       end
 
       def from_hstore hstore
-        @nested_serializer.deserialize(super)
+        @nested_serializer.deserialize(hstore)
       end
     end
   end


### PR DESCRIPTION
Consider a serializer class for a field containing an hstore. With ActiveRecord::Coders::Hstore it could look like this:

``` ruby
class CustomHstore
  def self.load(value)
    hash = value.from_hstore
    # Do something with hash
    hash
  end

  def self.dump(value)
    ActiveRecord::Coders::Hstore.dump(value)
  end
end
```

Since Rails 4.0 it turns into

``` ruby
class CustomHstore
  def self.load(hash)
    # Do something with hash

    hash
  end

  def self.dump(value)
    value
  end
end
```

Based on: http://big-elephants.com/2013-07/rails-4-and-activerecord-4-0/
