### PR TITLE
Remove the __TYPE__ from hstore for hashes

### DIFF
--- a/lib/nested_hstore/serializer.rb
+++ b/lib/nested_hstore/serializer.rb
@@ -6,7 +6,6 @@ module NestedHstore
       @types_map = {
         array: '__ARRAY__',
         float: '__FLOAT__',
-        hash: '__HASH__',
         integer: '__INTEGER__',
         string: '__STRING__'
       }
@@ -47,15 +46,15 @@ module NestedHstore
           hash.values.map { |v| decode_json_if_json(v) }
         when :float
           hash[@value_key].to_f
-        when :hash
-          hash.each do |k, v|
-            hash[k] = decode_json_if_json(v)
-          end
-          hash
         when :integer
           hash[@value_key].to_i
         when :string
           hash[@value_key]
+        else
+          hash.each do |k, v|
+            hash[k] = decode_json_if_json(v)
+          end
+          hash
       end
       deserialized
     end
@@ -73,7 +72,12 @@ module NestedHstore
           hstore[k] = v.to_s
         end
       end
-      hstore.merge(@type_key => @types_map[type])
+
+      if type != :hash
+        hstore.merge!(@type_key => @types_map[type])
+      end
+
+      hstore
     end
 
     def standardize_value(value)

--- a/spec/nested_hstore/serializer_spec.rb
+++ b/spec/nested_hstore/serializer_spec.rb
@@ -13,6 +13,7 @@ describe NestedHstore::Serializer do
     deserialized.should == @deserialized
   end
 
+
   context 'with a nested hash' do
     before :each do
       @deserialized = {
@@ -29,7 +30,6 @@ describe NestedHstore::Serializer do
       @serialized = {
        "a"=>"{\"b\":{\"c\":\"String 1\",\"d\":\"String 2\"}}",
        "e"=>"{\"f\":\"String 3\"}",
-       "__TYPE__"=>"__HASH__"
       }
     end
 
@@ -39,6 +39,31 @@ describe NestedHstore::Serializer do
 
     describe '#deserialize' do
       it('deserializes') { it_deserializes }
+    end
+
+    context 'with a type attribute' do
+      before :each do
+        @deserialized = {
+          'a' => {
+            'b' => {
+              'c' => 'String 1',
+              'd' => 'String 2'
+            }
+          },
+          'e' => {
+            'f' => 'String 3'
+          }
+        }
+        @serialized = {
+         "a"=>"{\"b\":{\"c\":\"String 1\",\"d\":\"String 2\"}}",
+         "e"=>"{\"f\":\"String 3\"}",
+         "__TYPE__"=>"__HASH__"
+        }
+      end
+
+      describe '#deserialize' do
+        it('deserializes') { it_deserializes }
+      end
     end
   end
 


### PR DESCRIPTION
Before this commit, plain hstores created before installing this gem were turned into nil, since they didn't have the **TYPE** attribute.

This removes the **TYPE** attribute for hashes, since that can just be the default case. That way old hstores work, while new ones created with the **TYPE** attribute also work.
