### PR TITLE
Remove dependency to activerecord-postgres-hstore

### DIFF
--- a/nested-hstore.gemspec
+++ b/nested-hstore.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.license       = 'MIT'
 
   s.add_dependency 'activerecord'
-  s.add_dependency 'activerecord-postgres-hstore'
   s.add_dependency 'activesupport'
 
   s.add_development_dependency 'appraisal'


### PR DESCRIPTION
I think we can get rid of this dependency since:

- Rails 4 doesn't require it, and
- README says to add `activerecord-postgres-hstore` for Rails 2/3