### PR TITLE
fixed casting string to hstore

### DIFF
--- a/lib/nested_hstore/serializer.rb
+++ b/lib/nested_hstore/serializer.rb
@@ -1,5 +1,7 @@
 module NestedHstore
   class Serializer
+    
+    include ActiveRecord::ConnectionAdapters::PostgreSQLColumn::Cast
 
     def initialize
       @type_key = '__TYPE__'
@@ -43,6 +45,7 @@ module NestedHstore
 
     def deserialize(hash)
       return nil if hash.nil?
+      hash = string_to_hstore(hash) if hash.is_a?(String)
       raise 'Hstore value should be a hash' unless hash.is_a?(Hash)
       type_value = hash.delete(@type_key)
       type = @types_map_inverted[type_value]

--- a/lib/nested_hstore/serializer.rb
+++ b/lib/nested_hstore/serializer.rb
@@ -1,3 +1,5 @@
+require "active_record/connection_adapters/postgresql/cast"
+
 module NestedHstore
   class Serializer
     


### PR DESCRIPTION
The problem occurs when I try to `#dup` a record with hstore column, my hstore column is before typecast, and it's a string so I get the 'Hstore value should be a hash' exception.

For example:

``` ruby
u = User.find(6)
new_setting = u.settings.find(123).dup
```

Interesting is, that problem doesn't occurs when I previously assign duplicated record to local variable and then `#dup`:

``` ruby
u = User.find(6)
old_setting = u.settings.find(123)
new_setting = old_setting.dup
```
